### PR TITLE
Symfony 6 User needs to implement PasswordAuthenticatedUserInterface

### DIFF
--- a/src/Core/User/UserInterface.php
+++ b/src/Core/User/UserInterface.php
@@ -4,30 +4,22 @@ declare(strict_types=1);
 
 namespace SyliusLabs\Polyfill\Symfony\Security\Core\User;
 
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
+// Symfony 5.4
 if (\method_exists(SymfonyUserInterface::class, 'getPassword')) {
     interface UserInterface extends SymfonyUserInterface
     {
     }
+// Symfony 6
 } else {
     /**
-     * @link https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/Security/Core/User/UserInterface.php
+     * @link https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/Security/Core/User/UserInterface.php
+     * @link https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/Security/Core/User/PasswordAuthenticatedUserInterface.php
      */
-    interface UserInterface extends SymfonyUserInterface
+    interface UserInterface extends SymfonyUserInterface, PasswordAuthenticatedUserInterface
     {
-        /**
-         * Returns the password used to authenticate the user.
-         *
-         * This should be the hashed password. On authentication, a plain-text
-         * password will be hashed, and then compared to this value.
-         *
-         * This method is deprecated since Symfony 5.3, implement it from {@link PasswordAuthenticatedUserInterface} instead.
-         *
-         * @return string|null The hashed password if any
-         */
-        public function getPassword();
-
         /**
          * Returns the salt that was originally used to hash the password.
          *


### PR DESCRIPTION
It's kinda BC break, as the `getPassword()` method has `?string` return type defined, but I'm not sure we can avoid it 🤷‍♂️ 