### PR TITLE
Fix missing LegacyPasswordAuthenticatedUserInterface

### DIFF
--- a/src/Core/User/UserInterface.php
+++ b/src/Core/User/UserInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SyliusLabs\Polyfill\Symfony\Security\Core\User;
 
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
 // Symfony 5.4
@@ -15,22 +15,11 @@ if (\method_exists(SymfonyUserInterface::class, 'getPassword')) {
 // Symfony 6
 } else {
     /**
+     * @link https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/Security/Core/User/LegacyPasswordAuthenticatedUserInterface.php
      * @link https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/Security/Core/User/UserInterface.php
-     * @link https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/Security/Core/User/PasswordAuthenticatedUserInterface.php
      */
-    interface UserInterface extends SymfonyUserInterface, PasswordAuthenticatedUserInterface
+    interface UserInterface extends LegacyPasswordAuthenticatedUserInterface, SymfonyUserInterface
     {
-        /**
-         * Returns the salt that was originally used to hash the password.
-         *
-         * This can return null if the password was not hashed using a salt.
-         *
-         * This method is deprecated since Symfony 5.3, implement it from {@link LegacyPasswordAuthenticatedUserInterface} instead.
-         *
-         * @return string|null The salt
-         */
-        public function getSalt();
-
         /**
          * @return string
          *


### PR DESCRIPTION
I would like to take advantage of `LegacyPasswordAuthenticatedUserInterface` which specifies `getSalt` method with `?string` return type. The existence of this interface is checked in Symfony in some places so if the interface exists, the salt will be used back 💃